### PR TITLE
0.30 fixed unwanted data persistence problem

### DIFF
--- a/pyflow/__init__.py
+++ b/pyflow/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.29"
+__version__ = "0.30"
 
 from .graph_builder import GraphBuilder
 from .node import DataHolderNode

--- a/pyflow/graph_builder.py
+++ b/pyflow/graph_builder.py
@@ -18,7 +18,16 @@ MAX_INTEGER = sys.maxsize
 
 class GraphBuilder():
     
-    def __init__(self, persist=False, verbose=False, alias=None, inside_pandasUDF=None):#, shared_args=dict()):
+    def __init__(self, alias=None, persist=False, verbose=False, inside_pandasUDF=None):#, shared_args=dict()):
+
+        if not (isinstance(alias, str) or alias is None):
+            raise TypeError("[ alias ] must be either None or string type")
+
+        if not isinstance(persist, bool):
+            raise TypeError("[ persist ] must be bool type")
+
+        if not isinstance(verbose, bool):
+            raise TypeError("[ verbose ] must be bool type")
 
         self.graph_alias = alias or "graph"
         self.graph_uid = "{}_{}".format(self.graph_alias, id(self))

--- a/pyflow/node/data_holder_node.py
+++ b/pyflow/node/data_holder_node.py
@@ -30,6 +30,9 @@ class DataHolderNode(BaseNode):
 
         The dimensionality of other types of data defaults to "(0)"
         """
+        if self.verbose:
+            print('persisting {}'.format(self.node_uid))
+            
         if not self.has_value:
             raise ValueError("There is no value!")
 


### PR DESCRIPTION
Prior to this fix, the __init__ method of GraphBuilder had positional parameters of [persist, alias... ].
Therefore, initializing the object by doing GraphBuilder("MyGraph") gave "MyGraph" value as persist argument, 
causing data to be persisted. This issue stemmed from bad usage example + ignorance of positional argument + negligence of type checking. 

The fixes are:
1) place alias first in the positional argument so that the example still works.
2) do type checking for each argument to make sure they are string, None, or boolean appropriately.

