### PR TITLE
0.31 Fixed another wanted data persistence problem

### DIFF
--- a/pyflow/__init__.py
+++ b/pyflow/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.30"
+__version__ = "0.31"
 
 from .graph_builder import GraphBuilder
 from .node import DataHolderNode

--- a/pyflow/graph_builder.py
+++ b/pyflow/graph_builder.py
@@ -330,9 +330,6 @@ class GraphBuilder():
         requested_data_nodes = [(k, v) for k, v in self.strong_ref_dict.items() 
                                      if v.node_uid in requested_data_node_uids]
         
-        for k, v in requested_data_nodes:
-            v.persist()
-        
         op_nodes = [(k, v) for k, v in self.strong_ref_dict.items() if v.node_type == 'operation']
 
         for k, v in op_nodes:
@@ -340,13 +337,6 @@ class GraphBuilder():
         
         for k, v in op_nodes:
             v.run()
-
-        # because op node calls get only on the parent data node, 
-        # and directly assigns the current function result to child node
-        # invoke get() on the last op node's child data node to make sure the 
-        # necessary persistance occurs.
-        for child_data_node_weak_ref in v.child_node_weak_refs:
-            child_data_node_weak_ref().get()
         
         if len(args) == 1:
             return args[0].get()

--- a/pyflow/graph_builder.py
+++ b/pyflow/graph_builder.py
@@ -329,6 +329,9 @@ class GraphBuilder():
         
         requested_data_nodes = [(k, v) for k, v in self.strong_ref_dict.items() 
                                      if v.node_uid in requested_data_node_uids]
+
+        for k, v in requested_data_nodes:
+            v.shallowly_persist()
         
         op_nodes = [(k, v) for k, v in self.strong_ref_dict.items() if v.node_type == 'operation']
 

--- a/pyflow/node/data_holder_node.py
+++ b/pyflow/node/data_holder_node.py
@@ -30,14 +30,16 @@ class DataHolderNode(BaseNode):
 
         The dimensionality of other types of data defaults to "(0)"
         """
-        if self.verbose:
-            print('persisting {}'.format(self.node_uid))
-            
         if not self.has_value:
             raise ValueError("There is no value!")
 
         if self.dim is not None:
+            if self.verbose:
+                print('{} has been persisted'.format(self.node_uid))
             return self.dim
+
+        if self.verbose:
+            print('persisting {}'.format(self.node_uid))
 
         try:
             is_spark_object = hasattr(self.value, "rdd")

--- a/pyflow/node/data_node.py
+++ b/pyflow/node/data_node.py
@@ -17,6 +17,8 @@ class DataNode(BaseNode):
 
         self.graph_dict = graph_dict
 
+        self.shallow_persist = False
+
     def set_value(self, value):
         
         self.value_holder.set_value(value)
@@ -28,10 +30,18 @@ class DataNode(BaseNode):
     def persist(self):
 
         self.data_persist = True
+
+    def shallowly_persist(self):
+
+        self.shallow_persist = True
         
     def is_persisted(self):
         
         return self.data_persist
+
+    def is_shallowly_persisted(self):
+
+        return self.shallow_persist
 
     def get_persisted_data_dim_as_str(self):
 
@@ -46,6 +56,9 @@ class DataNode(BaseNode):
         self.remove_dead_child_nodes()
         
         if self.value_holder.has_value():
+
+            if self.verbose and self.is_shallowly_persisted():
+                print('{} has been shallowly persisted'.format(self.node_uid))
 
             # update graph_dict 
             # during a computation execution, the value_holder can hold transient data

--- a/pyflow/node/data_node.py
+++ b/pyflow/node/data_node.py
@@ -52,9 +52,6 @@ class DataNode(BaseNode):
             # so we need to check that this data node is indeed persisted
             # as well as actually has data
             if self.is_persisted():
-                if self.verbose:
-                    print('persisted', self.node_uid)
-
                 data_dim = self.get_persisted_data_dim_as_str()
                 self.graph_dict[self.node_uid]['data_dim'] = data_dim
 
@@ -68,9 +65,6 @@ class DataNode(BaseNode):
 
             # update graph_dict
             if self.is_persisted():
-                if self.verbose:
-                    print('persisted', self.node_uid)
-
                 data_dim = self.get_persisted_data_dim_as_str()
                 self.graph_dict[self.node_uid]['data_dim'] = data_dim
 

--- a/pyflow/node/operation_node.py
+++ b/pyflow/node/operation_node.py
@@ -74,6 +74,10 @@ class OperationNode(BaseNode):
             # if the parent node is persisted, no need to check for its children op nodes
             if parent_data_node_weak_ref().is_persisted():
                 continue
+
+            # if the parent node is shallowly persisted, no need to check for its children op nodes
+            if parent_data_node_weak_ref().is_shallowly_persisted():
+                continue
             
             # checking the child op nodes of the current parent data node
             for child_op_node_weak_ref in parent_data_node_weak_ref().get_child_node_weak_refs():


### PR DESCRIPTION
State before this fix:

The run() method assumes that the user wants to save the data of specified data nodes that were passed in as arguments. For example, `result = G.run(last_node)` will have directed the "last_node" data node to persist itself. 
But pyflow should not make such assumption, especially when the data node is holding PySpark dataframe, since persisting will force the user through an expensive `count` method. 
If the user wanted it, he can specify persistence by doing: `G.add(last_method, persist=True)` to enforce the desired persistence behavior. 

After the fix:

The run() method does not assume the user wants the data persisted. Therefore, in case of underlying PySpark dataframe, it will not force the user to go through `count` method. However, without additional functionality, what may happen is that if we have a graph G whose topology is:

MethodA --> data_a --> MethodB --> data_b --> MethodC --> data_c

and call `G.run(data_b, data_c)`, it will calculate data_a as it is needed for data_b, and then release data_a, and when it calculates data_c, it will calculate data_a yet again, as well as data_b. (this is not exactly true but the gist of the problem is this exactly). This was not an issue before, because all of wanted data were persisted, so all you need to do is to just fetch them. 

We will therefore define a new concept of "shallow persistence". When a data node is shallowly persisted, it will not force the pyflow to calculate the data dimensionality the way "full" persistence will. However, it will also not release the memory of the data. In case of PySpark dataframe, the returned PySpark dataframe will not go through `count` method, but also will not disappear from memory, and therefore we will not need to do any overlapping calculations twice. The returned PySpark dataframe will be unpersisted dataframe. 

Other fixes:
1. Reorganized the way verbose condition prints out persistence to make it clearer. Now all persistence message emitted from data_holder_node since that's what does persisting, and all shallow persistence message will be emitted from data_node since that's where shallow persistence happens. 
2. Also, used proper past tense to make it logical where appropriate ("persist node_uid" --> "node_uid has been persisted")

