### PR TITLE
0.32 added support for keyword arguments

### DIFF
--- a/pyflow/__init__.py
+++ b/pyflow/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.31"
+__version__ = "0.32"
 
 from .graph_builder import GraphBuilder
 from .node import DataHolderNode

--- a/pyflow/node/operation_node.py
+++ b/pyflow/node/operation_node.py
@@ -3,10 +3,11 @@ from .base_node import BaseNode
 
 class OperationNode(BaseNode):
     
-    def __init__(self, graph_uid, graph_alias, node_uid, function, n_out, verbose=False, alias=None, graph_dict=None):
+    def __init__(self, graph_uid, graph_alias, node_uid, function, function_signature, n_out, verbose=False, alias=None, graph_dict=None):
         super(OperationNode, self).__init__(graph_uid, graph_alias, node_uid, 'operation', verbose, alias or function.__name__)
         
         self.function = function
+        self.function_signature = function_signature
         self.n_out = n_out
         self.is_active = False
 
@@ -48,10 +49,27 @@ class OperationNode(BaseNode):
                                     for parent_data_node_weak_ref 
                                     in self.parent_node_weak_refs]
 
+        # for v0.32
+        # reconstruct args and kwargs 
+        args = []
+        kwargs = {}
+
+        for key, val in zip(self.function_signature, parent_data_nodes_values):
+
+            if key is None:
+                args.append(val)
+
+            else:
+                kwargs[key] = val
+
         if self.verbose:
             print('running {}'.format(self.node_uid))
 
-        output_values = self.function(*parent_data_nodes_values)
+        output_values = self.function(*args, **kwargs)
+
+        # for v0.32
+        # desired state: output_values = self.function(*parent_data_nodes_values, **parent_named_data_nodes_values)
+        # perhaps we want to keep track of the names and non-names
         
         if self.n_out > 1:
             for i, output_value in enumerate(output_values):


### PR DESCRIPTION
Support for keyword arguments added.

Method signatures are saved in the operation node. From code comments in graph_builder.py file:

for v0.32
the names should be characteristics of the method not the inputs
the same input data can go in under different names for different methods
it ought to be part of the definition of the method signature
therefore, the name list must belong to the operation node and not the data node

For example, pyflow now supports doing:

    def methodA(other, elem, sr):

        return elem

    def methodB(elem, other):

        return elem

    def methodC(elem_too):

        return elem_too

    G = GraphBuilder(verbose=True)
    a = G.add(methodA)(3, sr='ef', elem=3)
    b = G.add(methodB)(other=5, elem=a)
    c = G.add(methodC, persist=False)(elem_too=b)
