### PR TITLE
0.33 add support for passing None

### DIFF
--- a/pyflow/__init__.py
+++ b/pyflow/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.32"
+__version__ = "0.33"
 
 from .graph_builder import GraphBuilder
 from .node import DataHolderNode

--- a/pyflow/graph_builder.py
+++ b/pyflow/graph_builder.py
@@ -141,8 +141,6 @@ class GraphBuilder():
             # if the inp is raw data, and not another data node
             else:
 
-                print(inp, 'asdf')
-
                 parent_data_node_uid = 'data_{}'.format(self.node_count)  # raw data has no alias
 
                 # if inp is raw value, we need to persist since we can't re-compute it from graph

--- a/pyflow/graph_builder.py
+++ b/pyflow/graph_builder.py
@@ -141,6 +141,8 @@ class GraphBuilder():
             # if the inp is raw data, and not another data node
             else:
 
+                print(inp, 'asdf')
+
                 parent_data_node_uid = 'data_{}'.format(self.node_count)  # raw data has no alias
 
                 # if inp is raw value, we need to persist since we can't re-compute it from graph

--- a/pyflow/node/data_holder_node.py
+++ b/pyflow/node/data_holder_node.py
@@ -6,7 +6,7 @@ import pandas as pd
 
 class DataHolderNode(BaseNode):
     
-    def __init__(self, graph_uid, graph_alias, node_uid, value=None, verbose=False):
+    def __init__(self, graph_uid, graph_alias, node_uid, value="__specialPFV__NoneData", verbose=False):
         super(DataHolderNode, self).__init__(graph_uid, graph_alias, node_uid, 'data_holder', verbose)
 
         self.value = value
@@ -19,7 +19,7 @@ class DataHolderNode(BaseNode):
         self.value = value
     
     def has_value(self):
-        return self.value is not None
+        return self.value is not "__specialPFV__NoneData"
 
     def get_persisted_data_dim_as_str(self):
         """Currently supports dimensionality from:

--- a/pyflow/node/data_node.py
+++ b/pyflow/node/data_node.py
@@ -6,7 +6,7 @@ import warnings
 
 class DataNode(BaseNode):
     
-    def __init__(self, graph_uid, graph_alias, node_uid, value=None, persist=False, verbose=False, alias=None, graph_dict=None):
+    def __init__(self, graph_uid, graph_alias, node_uid, value="__specialPFV__NoneData", persist=False, verbose=False, alias=None, graph_dict=None):
         super(DataNode, self).__init__(graph_uid, graph_alias, node_uid, 'data', verbose, alias or 'data')
         
         self.value_holder = DataHolderNode(graph_uid, graph_alias, self.node_uid, value, self.verbose)

--- a/pyflow/tests/test_graph_builder.py
+++ b/pyflow/tests/test_graph_builder.py
@@ -10,8 +10,11 @@ def multioutput_adding(a, b):
 
 def adding_kwarg(a, b, c=4):
     
-    return a + b + c
-
+    if c:
+        return a + b + c
+    else:
+        return a + b
+        
 def test_simple_graph():
     """GraphBuilder instance taking raw inputs"""
 

--- a/pyflow/tests/test_graph_builder.py
+++ b/pyflow/tests/test_graph_builder.py
@@ -8,6 +8,10 @@ def adding(a, b):
 def multioutput_adding(a, b):
     return a + b, a
 
+def adding_kwarg(a, b, c=4):
+    
+    return a + b + c
+
 def test_simple_graph():
     """GraphBuilder instance taking raw inputs"""
 
@@ -167,4 +171,84 @@ def test_multi_graph_with_persist():
     assert(~a4.has_value())
     assert(~a5.has_value())
     assert(a6.has_value())
+    
+def test_default_kwargs():
+    """Test default keyword arguments"""
+
+    G = GraphBuilder()
+    a1 = G.add(adding)(1, 2)
+    a2 = G.add(adding)(a1, 2)
+    a3 = G.add(adding_kwarg)(a1, a2)
+
+    assert(a3.get() == 12)
+    
+def test_kwargs_arguments():
+    """Test passing in keyword arguments"""
+
+    G = GraphBuilder()
+    a1 = G.add(adding)(1, 2)
+    a2 = G.add(adding)(a1, 2)
+    a3 = G.add(adding_kwarg)(a=a1, b=a2, c=10)
+
+    assert(a3.get() == 18)
+    
+def test_kwargs_None_arguments():
+    """Test None keyword argument input"""
+
+    G = GraphBuilder()
+    a1 = G.add(adding)(1, 2)
+    a2 = G.add(adding)(a1, 2)
+    a3 = G.add(adding_kwarg)(a=a1, b=a2, c=None)
+
+    assert(a3.get() == 8)
+    
+def test_args_None_arguments():
+    """Test None positional argument input"""
+
+    G = GraphBuilder()
+    a1 = G.add(adding)(1, 2)
+    a2 = G.add(adding)(a1, 2)
+    a3 = G.add(adding_kwarg)(a1, a2, None)
+
+    assert(a3.get() == 8)
+    
+def test_kwargs_None_arguments_multi_graph():
+    """Test None keyword/positional argument input in multiple graph paradigm"""
+
+    G = GraphBuilder()
+    a1 = G.add(adding)(1, 2)
+    a2 = G.add(adding)(a1, 2)
+    a3 = G.add(adding_kwarg)(a=a1, b=a2, c=None)
+
+    H = GraphBuilder()
+    a4 = H.add(adding)(a3, 1)
+    a5 = H.add(adding)(a4, 2)
+    a6 = G.add(adding_kwarg)(a4, a5, None)
+
+    assert(a6.get() == 20)
+    
+def test_kwargs_None_arguments_multi_graph_with_persist():
+    """Test None keyword argument input in multiple graph paradigm with persist"""
+
+    G = GraphBuilder()
+    a1 = G.add(adding)(1, 2)
+    a2 = G.add(adding)(a1, 2)
+    a3 = G.add(adding_kwarg, persist=True)(a=a1, b=a2, c=None)
+
+    H = GraphBuilder()
+    a4 = H.add(adding)(a3, 1)
+    a5 = H.add(adding)(a4, 2)
+    a6 = H.add(adding)(a4, a5)
+
+    a6.get()
+
+    assert(~a1.has_value())
+    assert(~a2.has_value())
+    assert(a3.has_value())
+
+    assert(~a4.has_value())
+    assert(~a5.has_value())
+    assert(a6.has_value())
+
+    assert(a6.get() == 20)
     


### PR DESCRIPTION
This issue before the fix:

Pyflow was unable to take in None as input argument. This was a big failure case as we often do pass in None as an argument. This was due to data_holder_node having a default value of None and checking whether or not it was holding any value by checking if its value field is None.

How it was resolved:

Now the default value is a particular string value "__specialPFV__NoneData", and whether the data_holder_node is holding a value is checked against this default value. Therefore, None is effectively considered as a valid value that data_holder_node can hold. 

Additional pytest cases were added.