### PR TITLE
0.34 persisting data node with op nodes with no return statements

### DIFF
--- a/pyflow/__init__.py
+++ b/pyflow/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.33"
+__version__ = "0.34"
 
 from .graph_builder import GraphBuilder
 from .node import DataHolderNode

--- a/pyflow/node/base_node.py
+++ b/pyflow/node/base_node.py
@@ -32,18 +32,22 @@ class BaseNode(object):
     def remove_dead_parent_nodes(self):
 
         self.parent_node_weak_refs = [elem for elem in self.parent_node_weak_refs if elem() is not None]
-        
-    def has_parent_node_weak_refs(self):
-
-        return len(self.parent_node_weak_refs) > 0
     
     def get_parent_node_weak_refs(self):
 
         return self.parent_node_weak_refs
+
+    def has_parent_node_weak_refs(self):
+
+        return len(self.parent_node_weak_refs) > 0
         
     def get_child_node_weak_refs(self):
 
         return self.child_node_weak_refs
+
+    def has_child_node_weak_refs(self):
+
+        return len(self.child_node_weak_refs) > 0
     
     def get_node_uid(self):
 

--- a/pyflow/node/operation_node.py
+++ b/pyflow/node/operation_node.py
@@ -105,6 +105,22 @@ class OperationNode(BaseNode):
                 # also, we do not care about the status of data nodes under this op node
                 if not child_op_node_weak_ref().is_activated():
                     continue
+
+                # if the child op node of this parent data node is activated (by prior check)
+                # but if this child op node has no return values, 
+                # then we assume that this parent data node is still needed by the op node
+                # and therefore we do not release it
+                if not child_op_node_weak_ref().get_child_node_weak_refs():
+
+                    if self.verbose:
+                        print('{} still needed at {}'.format(parent_data_node_weak_ref().get_node_uid(), 
+                                                             child_op_node_weak_ref().get_node_uid()))
+
+                    # at this point, we don't need to check any other child op node of 
+                    # this parent data node.
+                    # however, we may need to check the next parent_data_node_weak_ref
+                    release_parent_data_node = False
+                    break
                 
                 # now traversing down to the data nodes of the op node
                 # if any of the data nodes are not filled, we need the current data node
@@ -119,6 +135,7 @@ class OperationNode(BaseNode):
                         
                         # for op node with one output data node, this weakref is referring to the
                         # output node it just computed for
+
                         if self.verbose:
                             print('{} still needed at {}'.format(parent_data_node_weak_ref().get_node_uid(), 
                                                                  child_op_node_weak_ref().get_node_uid()))

--- a/pyflow/node/operation_node.py
+++ b/pyflow/node/operation_node.py
@@ -110,7 +110,7 @@ class OperationNode(BaseNode):
                 # but if this child op node has no return values, 
                 # then we assume that this parent data node is still needed by the op node
                 # and therefore we do not release it
-                if not child_op_node_weak_ref().get_child_node_weak_refs():
+                if not child_op_node_weak_ref().has_child_node_weak_refs():
 
                     if self.verbose:
                         print('{} still needed at {}'.format(parent_data_node_weak_ref().get_node_uid(), 

--- a/pyflow/node/operation_node.py
+++ b/pyflow/node/operation_node.py
@@ -118,7 +118,7 @@ class OperationNode(BaseNode):
 
                     # at this point, we don't need to check any other child op node of 
                     # this parent data node.
-                    # however, we may need to check the next parent_data_node_weak_ref
+                    # however, we may need to check the next parent_data_node_weak_ref of this op node
                     release_parent_data_node = False
                     break
                 
@@ -142,7 +142,7 @@ class OperationNode(BaseNode):
 
                         # at this point, we don't need to check any other child op node of 
                         # this parent data node.
-                        # however, we may need to check the next parent_data_node_weak_ref
+                        # however, we may need to check the next parent_data_node_weak_ref of this op node
                         release_parent_data_node = False
                         break
                 


### PR DESCRIPTION
ISSUE:

Prior to the fix, the condition to persist a data node has been to check that there exists at least one child operation node (that is activated) of that data node that has child data nodes that are still not computed. But this creates an edge case where if the child operation node of that data node has NO RETURN STATEMENT, then it will automatically fail to meet the persistence condition, and therefore prematurely release the memory of that data node, leading to failure of the child operation node with no return statement. 

Example failure case:

from pyflow import GraphBuilder

def adding(a, b):
    return a + b

def adding3(a, b):
    a + b

G = GraphBuilder(alias='A', verbose=True)    

a = G.add(adding, persist=False)(1, 2)
b = G.add(adding)(a, 2)
c = G.add(adding3)(a, a)

G.run()

SOLUTION:

When checking for the persistence condition for a particular data node, if there is a child operation node that has no return statement, and it is activated, then we assume that the data node is needed by that return-less operation node, and hence we persist that data node. 